### PR TITLE
Fix View in Seq HREF

### DIFF
--- a/src/Seq.App.DigestEmail/Resources/DefaultBodyTemplate.html
+++ b/src/Seq.App.DigestEmail/Resources/DefaultBodyTemplate.html
@@ -137,7 +137,7 @@
           <span class="seq-message-template">[<strong>{{$Level}}</strong>] {{$Message}}</span>
         </div>
         <div class="seq-event-actions" style="margin-top:5px;">
-          <a href="{{{$ServerUri}}}#/events?filter=@Id%3D'{{$Id}}'&show=expanded" class="action" style="color:#007acc;text-decoration:none;padding-right:10px;font-size:12px;">View in Seq</a>
+          <a href="{{{../$ServerUri}}}#/events?filter=@Id%3D'{{$Id}}'&show=expanded" class="action" style="color:#007acc;text-decoration:none;padding-right:10px;font-size:12px;">View in Seq</a>
         </div>
         <div class="seq-event-properties" style="margin-top:5px;">
           {{#each $Properties}}

--- a/src/Seq.App.DigestEmail/Resources/RawBodyTemplate.html
+++ b/src/Seq.App.DigestEmail/Resources/RawBodyTemplate.html
@@ -140,7 +140,7 @@
         <span class="seq-message-template">[<strong>{{$Level}}</strong>] {{$Message}}</span>
       </div>
       <div class="seq-event-actions">
-        <a href="{{{$ServerUri}}}#/events?filter=@Id%3D'{{$Id}}'&show=expanded" class="action">View in Seq</a>
+        <a href="{{{../$ServerUri}}}#/events?filter=@Id%3D'{{$Id}}'&show=expanded" class="action">View in Seq</a>
       </div>
       <div class="seq-event-properties">
         {{#each $Properties}}

--- a/src/Seq.App.DigestEmail/Seq.App.DigestEmail.csproj
+++ b/src/Seq.App.DigestEmail/Seq.App.DigestEmail.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Handlebars, Version=1.0.0.0, Culture=neutral, PublicKeyToken=22225d0bf33cd661, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Handlebars.Net.1.7.1\lib\Handlebars.dll</HintPath>
+      <HintPath>..\..\packages\Handlebars.Net.1.8.0\lib\portable-net45+sl5+wp8+win8\Handlebars.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">

--- a/src/Seq.App.DigestEmail/packages.config
+++ b/src/Seq.App.DigestEmail/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Handlebars.Net" version="1.7.1" targetFramework="net45" />
+  <package id="Handlebars.Net" version="1.8.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Seq.Apps" version="3.4.17" targetFramework="net45" />
   <package id="Serilog" version="2.0.0" targetFramework="net45" />

--- a/test/Seq.App.DigestEmail.Tests/Seq.App.DigestEmail.Tests.csproj
+++ b/test/Seq.App.DigestEmail.Tests/Seq.App.DigestEmail.Tests.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Handlebars, Version=1.0.0.0, Culture=neutral, PublicKeyToken=22225d0bf33cd661, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Handlebars.Net.1.7.1\lib\Handlebars.dll</HintPath>
+      <HintPath>..\..\packages\Handlebars.Net.1.8.0\lib\portable-net45+sl5+wp8+win8\Handlebars.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Seq.Apps, Version=3.4.17.0, Culture=neutral, processorArchitecture=MSIL">

--- a/test/Seq.App.DigestEmail.Tests/packages.config
+++ b/test/Seq.App.DigestEmail.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Handlebars.Net" version="1.7.1" targetFramework="net45" />
+  <package id="Handlebars.Net" version="1.8.0" targetFramework="net45" />
   <package id="Seq.Apps" version="3.4.17" targetFramework="net45" />
   <package id="Serilog" version="2.0.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />


### PR DESCRIPTION
A `../` "parent context" reference was missing.

Also takes the opportunity to update to Handlebars.NET 1.8.0.